### PR TITLE
Support multiple platforms for SNP data.

### DIFF
--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/BioAssayGenoPlatformProbe.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/BioAssayGenoPlatformProbe.groovy
@@ -21,7 +21,6 @@ package org.transmartproject.db.dataquery.highdim.snp_lz
 
 class BioAssayGenoPlatformProbe {
 
-    Long bioAssayPlatformId
     String origChrom
     BigDecimal origPosition
     String origGenomeBuild
@@ -38,13 +37,17 @@ class BioAssayGenoPlatformProbe {
     Date dateCreated
     Date lastUpdated
 
-    static mapping = {
-        table        schema:  'biomart'
-        id           column:  'bio_asy_geno_platform_probe_id',  generator:  'assigned'
+    static belongsTo = [
+        bioAssayPlatform: CoreBioAssayPlatform,
+    ]
 
-        dateCreated  column:  'created_date'
-        lastUpdated  column:  'modified_date'
-        version      false
+    static mapping = {
+        table               schema:  'biomart'
+        id                  column:  'bio_asy_geno_platform_probe_id',  generator:  'assigned'
+        bioAssayPlatform    column:  'bio_assay_platform_id',  generator: 'assigned'
+        dateCreated         column:  'created_date'
+        lastUpdated         column:  'modified_date'
+        version             false
     }
 
     static constraints = {
@@ -54,6 +57,8 @@ class BioAssayGenoPlatformProbe {
         probeName        nullable:  true,  maxSize:  200
 
         //isControl      nullable:  true,  maxSize:  1
+
+        bioAssayPlatform nullable:  true
 
         createdBy        nullable:  true,  maxSize:  30
         dateCreated      nullable:  true

--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/CoreBioAssayPlatform.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/CoreBioAssayPlatform.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2016 The Hyve B.V.
+ *
+ * This file is part of transmart-core-db.
+ *
+ * Transmart-core-db is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * transmart-core-db.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.transmartproject.db.dataquery.highdim.snp_lz
+
+class CoreBioAssayPlatform {
+
+    String name
+    String version
+    String description
+    String array
+    String accession
+    String organism
+    String vendor
+    String type
+    String technology
+    String imputedAlgorithm
+    String imputedPanel
+    String imputed
+
+    String createdBy
+    String modifiedBy
+    Date dateCreated
+    Date lastUpdated
+
+    static mapping = {
+        table               name: 'bio_assay_platform',  schema:  'biomart'
+        id                  column:  'bio_assay_platform_id',  generator:  'assigned'
+
+        name                column:  'platform_name'
+        version             column:  'platform_version'
+        description         column:  'platform_description'
+        array               column:  'platform_array'
+        accession           column:  'platform_accession'
+        organism            column:  'platform_organism'
+        vendor              column:  'platform_vendor'
+        type                column:  'platform_type'
+        technology          column:  'platform_technology'
+        imputedAlgorithm    column:  'platform_imputed_algorithm'
+        imputedPanel        column:  'platform_imputed_panel'
+        imputed             column:  'platform_imputed'
+
+        dateCreated         column:  'created_date'
+        lastUpdated         column:  'modified_date'
+        version             false
+    }
+
+    static constraints = {
+        name                nullable:  true,  maxSize:  200
+        version             nullable:  true,  maxSize:  200
+        description         nullable:  true,  maxSize:  2000
+        array               nullable:  true,  maxSize:  50
+        accession           nullable:  true,  maxSize:  20
+        organism            nullable:  true,  maxSize:  200
+        vendor              nullable:  true,  maxSize:  200
+        type                nullable:  true,  maxSize:  200
+        technology          nullable:  true,  maxSize:  200
+        imputedAlgorithm    nullable:  true,  maxSize:  500
+        imputedPanel        nullable:  true,  maxSize:  200
+        imputed             nullable:  true,  maxSize:  1
+    
+        createdBy           nullable:  true,  maxSize:  30
+        dateCreated         nullable:  true
+        modifiedBy          nullable:  true,  maxSize:  30
+        lastUpdated         nullable:  true
+    }
+}

--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/SnpSubjectSortedDef.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/SnpSubjectSortedDef.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2015 The Hyve B.V.
+ * Copyright © 2013-2016 The Hyve B.V.
  *
  * This file is part of transmart-core-db.
  *
@@ -29,20 +29,22 @@ class SnpSubjectSortedDef {
 
     static belongsTo = [
             patient: PatientDimension,
+            bioAssayPlatform: CoreBioAssayPlatform,
     ]
 
     static mapping = {
-        table    schema:  'deapp', name: 'de_snp_subject_sorted_def'
-
-        id       column:  'snp_subject_sorted_def_id',  generator:  'assigned'
-        patient  column:  'patient_num'
-        version  false
+        table               schema:  'deapp',  name:  'de_snp_subject_sorted_def'
+        id                  column:  'snp_subject_sorted_def_id',        generator:  'assigned'
+        patient             column:  'patient_num'
+        bioAssayPlatform    column:  'bio_assay_platform_id', generator:  'assigned'
+        version             false
     }
 
     static constraints = {
-        trialName        nullable:  true
-        patientPosition  nullable:  true
-        patient          nullable:  true
-        subjectId        nullable:  true
+        trialName           nullable:  true
+        patientPosition     nullable:  true
+        patient             nullable:  true
+        bioAssayPlatform    nullable:  true
+        subjectId           nullable:  true
     }
 }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzModule.groovy
@@ -187,6 +187,34 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
         return trials[0]
     }
 
+    /**
+     * Get the platform id from a collection of assays.
+     * The assays should belong to exactly one platform, since the
+     * snp_lz rows contain data for all subjects in a trial.
+     * @param assays the collection of assays for which the data
+     *  is queried.
+     * @throws EmptySetException iff the collection contains no platform ids
+     *  (i.e., the set of assays is empty).
+     * @throws UnexpectedResultException iff the collection multiple platform ids.
+     * @return the platform id.
+     */
+    String getBioAssayPlatformIdFromAssays(Collection<AssayColumn> assays) {
+        def platforms = [] as Set
+        assays.each { platforms << it.platform.id }
+        log.debug "Set of platforms for assays: $platforms"
+
+        if (platforms.size() == 0) {
+            throw new EmptySetException(
+                    "Assay set $platforms has no platform information")
+        } else if (platforms.size() > 1) {
+            // Do not permit more than one platform, otherwise we wouldn't be able
+            // to returns meaningful row properties.
+            throw new UnexpectedResultException("Found more than one platform in " +
+                    "the assay set; this is not allowed for this data type")
+        }
+        return platforms[0]
+    }
+
     HibernateCriteriaBuilder prepareDataQuery(
         Projection projection,
         SessionImplementor session) {
@@ -205,8 +233,13 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
         def trialName = getTrialNameFromAssays(assays)
         log.debug "Add constraint for trailName '${trialName}'"
 
+        def platformId = getBioAssayPlatformIdFromAssays(assays)
+        log.debug "Add constraint for platformId '${platformId}'"
+
         criteriaBuilder.with {
             createAlias 'genotypeProbeAnnotation', 'ann',       INNER_JOIN
+            createAlias 'bioAssayGenoPlatform',    'assay_platform',  INNER_JOIN
+            createAlias 'assay_platform.bioAssayPlatform',  'platform',  INNER_JOIN
 
             projections {
                 property 'snp.a1',                     'a1'
@@ -228,6 +261,8 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
                 property 'ann.snpName',                'snpName'
                 property 'ann.chromosome',             'chromosome'
                 property 'ann.pos',                    'position'
+
+                property 'platform.accession',         'platformId'
             }
 
             /*
@@ -236,6 +271,12 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
              * subjects in a particular trial.
              */
             eq 'snp.trialName', trialName
+
+            /*
+             * This constraint is required in the case there is SNP data for multiple
+             * platforms within a trial.
+             */
+            eq 'platform.accession', platformId
 
             /*
              * Constraint required to prevent duplicates when multiple genome
@@ -257,8 +298,13 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
                                    Projection projection) {
 
         def trials = [] as Set
-        assays.each { trials << it.trialName }
+        def platforms = [] as Set
+        assays.each {
+            trials << it.trialName
+            platforms << it.platform.id
+        }
         log.debug "Set of trials for assays: $trials"
+        log.debug "Set of platforms for assays: $platforms"
 
         if (trials.size() == 0) {
             throw new EmptySetException(
@@ -271,9 +317,24 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
                     "the assay set; this is not allowed for this data type")
         }
 
+        if (platforms.size() == 0) {
+            throw new EmptySetException(
+                    "Assay set $platforms has no platform information")
+        } else if (platforms.size() > 1) {
+            // Do not permit more than one platform, otherwise we wouldn't be able
+            // to returns meaningful row properties (or we'd have to make them
+            // maps)
+            throw new UnexpectedResultException("Found more than one platform in " +
+                    "the assay set; this is not allowed for this data type")
+        }
+
+        log.debug "Querying patient order for trial '${trials.first()}' and platform '${platforms.first()}'."
         // obtain patient order for all of the trials of the result
         def sssList = SnpSubjectSortedDef.createCriteria().list {
+            createAlias 'bioAssayPlatform',  'platform',  INNER_JOIN
+
             eq 'trialName', trials.first()
+            eq 'platform.accession', platforms.first()
             order 'patientPosition', 'asc'
 
             fetchSize SNP_PATIENTS_FETCH_SIZE

--- a/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzTestDataSinglePlatform.groovy
+++ b/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzTestDataSinglePlatform.groovy
@@ -42,19 +42,17 @@ import java.util.zip.GZIPOutputStream
 
 import static org.transmartproject.db.dataquery.highdim.HighDimTestData.save
 
-class SnpLzTestData {
+class SnpLzTestDataSinglePlatform {
     public static final String TRIAL_NAME = 'CARDS'
     public static final String CONCEPT_PATH = "\\\\i2b2 main\\foo\\${TRIAL_NAME}\\concept code #1"
     public static final String PLATFORM = 'Perlegen_600k'
-    public List<String> conceptCodes = ['concept code #1', 'concept code #2']
+    public List<String> conceptCodes = ['concept code #1']
 
     List<DeSubjectSampleMapping> assays
 
-    SnpLzTestData() {
+    SnpLzTestDataSinglePlatform() {
         assays = HighDimTestData.createTestAssays(
                 patients, -400, platforms[0], TRIAL_NAME, concepts[1].conceptCode, platforms[0].title)
-        assays += HighDimTestData.createTestAssays(
-                patients, -200, platforms[1], TRIAL_NAME, concepts[2].conceptCode, platforms[1].title)
     }
 
     List<TableAccess> i2b2TopConcepts = [
@@ -65,7 +63,6 @@ class SnpLzTestData {
     List<I2b2> i2b2Concepts = [
             createI2b2Concept(code: 1, level: 1, fullName: "\\foo\\${TRIAL_NAME}\\", name: TRIAL_NAME),
             createI2b2Concept(code: 2, level: 2, fullName: "\\foo\\${TRIAL_NAME}\\${conceptCodes[0]}\\", name: conceptCodes[0]),
-            createI2b2Concept(code: 3, level: 2, fullName: "\\foo\\${TRIAL_NAME}\\${conceptCodes[1]}\\", name: conceptCodes[1]),
     ]
 
     List<ConceptDimension> concepts = createConceptDimensions(i2b2Concepts)
@@ -83,7 +80,6 @@ class SnpLzTestData {
         }
         [
             createPlatform('Perlegen_600k', 'Homo Sapiens', 'SNP'),
-            createPlatform('CARDSSNP', 'Homo Sapiens', 'SNP'),
         ]
     }()
 
@@ -221,18 +217,6 @@ class SnpLzTestData {
         tb.put assays[2].sampleCode, annotations[1].snpName, '0 0 1'
         tb.put assays[2].sampleCode, annotations[2].snpName, '0 1 0'
 
-        tb.put assays[3].sampleCode, annotations[0].snpName, '0 0 1'
-        tb.put assays[3].sampleCode, annotations[1].snpName, '0 1 0'
-        tb.put assays[3].sampleCode, annotations[2].snpName, '0 0 0'
-
-        tb.put assays[4].sampleCode, annotations[0].snpName, '1 0 0'
-        tb.put assays[4].sampleCode, annotations[1].snpName, '0 0 0'
-        tb.put assays[4].sampleCode, annotations[2].snpName, '1 0 0'
-
-        tb.put assays[5].sampleCode, annotations[0].snpName, '0 0 1'
-        tb.put assays[5].sampleCode, annotations[1].snpName, '0 0 1'
-        tb.put assays[5].sampleCode, annotations[2].snpName, '0 1 0'
-
         tb.build()
     }()
 
@@ -252,18 +236,6 @@ class SnpLzTestData {
         tb.put assays[2].sampleCode, annotations[1].snpName, 'A A'
         tb.put assays[2].sampleCode, annotations[2].snpName, 'A T'
 
-        tb.put assays[3].sampleCode, annotations[0].snpName, 'A A'
-        tb.put assays[3].sampleCode, annotations[1].snpName, 'A T'
-        tb.put assays[3].sampleCode, annotations[2].snpName, 'N N'
-
-        tb.put assays[4].sampleCode, annotations[0].snpName, 'T T'
-        tb.put assays[4].sampleCode, annotations[1].snpName, 'N N'
-        tb.put assays[4].sampleCode, annotations[2].snpName, 'T T'
-
-        tb.put assays[5].sampleCode, annotations[0].snpName, 'A A'
-        tb.put assays[5].sampleCode, annotations[1].snpName, 'A A'
-        tb.put assays[5].sampleCode, annotations[2].snpName, 'A T'
-
         tb.build()
     }()
 
@@ -282,18 +254,6 @@ class SnpLzTestData {
         tb.put assays[2].sampleCode, annotations[0].snpName, '0'
         tb.put assays[2].sampleCode, annotations[1].snpName, '0'
         tb.put assays[2].sampleCode, annotations[2].snpName, '1'
-
-        tb.put assays[3].sampleCode, annotations[0].snpName, '0'
-        tb.put assays[3].sampleCode, annotations[1].snpName, '1'
-        tb.put assays[3].sampleCode, annotations[2].snpName, '0'
-
-        tb.put assays[4].sampleCode, annotations[0].snpName, '2'
-        tb.put assays[4].sampleCode, annotations[1].snpName, '0'
-        tb.put assays[4].sampleCode, annotations[2].snpName, '2'
-
-        tb.put assays[5].sampleCode, annotations[0].snpName, '0'
-        tb.put assays[5].sampleCode, annotations[1].snpName, '0'
-        tb.put assays[5].sampleCode, annotations[2].snpName, '1'
 
         tb.build()
     }()

--- a/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/HighDimensionAllDataTests.groovy
+++ b/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/HighDimensionAllDataTests.groovy
@@ -39,7 +39,7 @@ import org.transmartproject.db.dataquery.highdim.protein.ProteinTestData
 import org.transmartproject.db.dataquery.highdim.rbm.RbmTestData
 import org.transmartproject.db.dataquery.highdim.rnaseq.RnaSeqTestData
 import org.transmartproject.db.dataquery.highdim.rnaseqcog.RnaSeqCogTestData
-import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzTestData
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzTestDataSinglePlatform
 import org.transmartproject.db.dataquery.highdim.vcf.VcfTestData
 import org.transmartproject.db.test.RuleBasedIntegrationTestMixin
 
@@ -122,7 +122,7 @@ class HighDimensionAllDataTests {
              imputeQuality:BigDecimal, GTProbabilityThreshold:BigDecimal,
              minorAlleleFrequency:BigDecimal, minorAllele:String,
              a1a1Count:Long, a1a2Count:Long, a2a2Count:Long, noCallCount:Long],
-            SnpLzTestData
+            SnpLzTestDataSinglePlatform
         ]
     ].collect {it.toArray()}}
 


### PR DESCRIPTION
Add a platform constraint for querying SNP data,
in order to support multiple SNP data sets for
different platforms within a trial.